### PR TITLE
INF-2757 Allow SMTP emails so we can send to Google Groups

### DIFF
--- a/scripts/send_monthly_agency_emails.py
+++ b/scripts/send_monthly_agency_emails.py
@@ -24,6 +24,13 @@ def get_last_month(this_month=date.today().month):
 @click.option("--cc", "cc_addrs", multiple=True, default=[])
 @click.option("--bcc", "bcc_addrs", multiple=True, default=[])
 @click.option("--admin", "admin_addrs", multiple=True, default=[])
+@click.option("--smtp_server", type=str, default=None)
+@click.option("--smtp_username", type=str, default=None)
+@click.option(
+    "--smtp_password_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    default=None,
+)
 @click.option(
     "--account_index", envvar="CAS_ACCOUNT_INDEX", default="cas-credit-accounts"
 )
@@ -51,6 +58,9 @@ def main(
     cc_addrs,
     bcc_addrs,
     admin_addrs,
+    smtp_server,
+    smtp_username,
+    smtp_password_file,
 ):
     es_client = connect(es_host, es_user, es_pass, es_use_https, es_ca_certs)
 
@@ -73,6 +83,9 @@ def main(
             list(bcc_addrs),
             list(attachments.values()),
             html,
+            smtp_server,
+            smtp_username,
+            smtp_password_file,
         )
     except Exception as e:
         error_str = f"Error while sending '{subject}':\n\t{str(e)}"

--- a/scripts/send_weekly_admin_email.py
+++ b/scripts/send_weekly_admin_email.py
@@ -18,6 +18,13 @@ from cas_admin.email_utils import send_email, generate_weekly_accounts_report
 @click.option("--cc", "cc_addrs", multiple=True, default=[])
 @click.option("--bcc", "bcc_addrs", multiple=True, default=[])
 @click.option("--admin", "admin_addrs", multiple=True, default=[])
+@click.option("--smtp_server", type=str, default=None)
+@click.option("--smtp_username", type=str, default=None)
+@click.option(
+    "--smtp_password_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    default=None,
+)
 @click.option(
     "--account_index", envvar="CAS_ACCOUNT_INDEX", default="cas-credit-accounts"
 )
@@ -45,6 +52,9 @@ def main(
     cc_addrs,
     bcc_addrs,
     admin_addrs,
+    smtp_server,
+    smtp_username,
+    smtp_password_file,
 ):
     es_client = connect(es_host, es_user, es_pass, es_use_https, es_ca_certs)
 
@@ -67,6 +77,9 @@ def main(
             list(bcc_addrs),
             list(attachments.values()),
             html,
+            smtp_server,
+            smtp_username,
+            smtp_password_file,
         )
     except Exception as e:
         error_str = f"Error while sending '{subject}':\n\t{str(e)}"

--- a/scripts/send_weekly_owner_emails.py
+++ b/scripts/send_weekly_owner_emails.py
@@ -27,6 +27,13 @@ IS_MONTHLY = date.today().day <= 7
 @click.option("--cc", "cc_addrs", multiple=True, default=[])
 @click.option("--bcc", "bcc_addrs", multiple=True, default=[])
 @click.option("--admin", "admin_addrs", multiple=True, default=[])
+@click.option("--smtp_server", type=str, default=None)
+@click.option("--smtp_username", type=str, default=None)
+@click.option(
+    "--smtp_password_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    default=None,
+)
 @click.option("--no_email_owners", "no_email_owners", is_flag=True)
 @click.option("--account", "account_ids", multiple=True, default=[])
 @click.option("--force", "force_send", is_flag=True)
@@ -64,6 +71,9 @@ def main(
     cc_addrs,
     bcc_addrs,
     admin_addrs,
+    smtp_server,
+    smtp_username,
+    smtp_password_file,
     no_email_owners,
     account_ids,
     force_send,
@@ -104,6 +114,9 @@ def main(
                     replyto_addr,
                     attachments=list(attachments.values()),
                     html=html,
+                    smtp_server=smtp_server,
+                    smtp_username=smtp_username,
+                    smtp_password_file=smtp_password_file,
                 )
         except Exception as e:
             error_str = f"Error while sending '{subject}':\n\t{str(e)}"


### PR DESCRIPTION
Google Groups is a little more picky about who can send them email. These changes allow us to use a specific SMTP server to send emails, which can handle authentication and all the DMARC stuff so our emails don't get canned.